### PR TITLE
Revert "Update dependency typescript to v5"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@typescript-eslint/parser": "5.62.0",
         "eslint": "8.57.0",
         "ts-node": "10.9.2",
-        "typescript": "5.4.4"
+        "typescript": "4.9.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1851,16 +1851,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
-      "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@typescript-eslint/parser": "5.62.0",
     "eslint": "8.57.0",
     "ts-node": "10.9.2",
-    "typescript": "5.4.4"
+    "typescript": "4.9.5"
   },
   "dependencies": {
     "axios": "^1.0.0",


### PR DESCRIPTION
Reverts syou6162/esa_recent_posts_logger#90

https://github.com/syou6162/esa_recent_posts_logger/actions/runs/8602439748/job/23572009488 が落ちるようになったので、戻してみる