### PR TITLE
Revert "Update dependency date-fns to v3"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.0.0",
-        "date-fns": "^3.0.0",
+        "date-fns": "^2.21.1",
         "date-fns-timezone": "^0.1.4"
       },
       "devDependencies": {
@@ -30,6 +30,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -662,12 +673,18 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
       "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/date-fns-timezone": {
@@ -1591,6 +1608,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "axios": "^1.0.0",
-    "date-fns": "^3.0.0",
+    "date-fns": "^2.21.1",
     "date-fns-timezone": "^0.1.4"
   }
 }


### PR DESCRIPTION
Reverts syou6162/esa_recent_posts_logger#164

動かなくなっているので、戻す。

- https://github.com/syou6162/esa_recent_posts_logger/actions/runs/8604156596/job/23577631636

```
⨯ Unable to compile TypeScript:
Error: src/index.ts(5[8](https://github.com/syou6162/esa_recent_posts_logger/actions/runs/8604156596/job/23577631636#step:5:9),22): error TS2349: This expression is not callable.
  Type 'typeof import("/home/runner/work/esa_recent_posts_logger/esa_recent_posts_logger/node_modules/date-fns/format")' has no call signatures.
Error: src/index.ts(5[9](https://github.com/syou6162/esa_recent_posts_logger/actions/runs/8604156596/job/23577631636#step:5:10),20): error TS2349: This expression is not callable.
  Type 'typeof import("/home/runner/work/esa_recent_posts_logger/esa_recent_posts_logger/node_modules/date-fns/format")' has no call signatures.
Error: src/index.ts([11](https://github.com/syou6162/esa_recent_posts_logger/actions/runs/8604156596/job/23577631636#step:5:12)4,26): error TS2349: This expression is not callable.
  Type 'typeof import("/home/runner/work/esa_recent_posts_logger/esa_recent_posts_logger/node_modules/date-fns/format")' has no call signatures.
Error: Process completed with exit code 1.
```